### PR TITLE
fix: update deprecated Yazi API calls and first-visit preview bug

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -2,19 +2,19 @@ local M = {}
 
 function M:peek(job)
 	local start, cache = os.clock(), ya.file_cache(job)
-	if not cache or self:preload() ~= 1 then
+	if not cache or self:preload(job) ~= 1 then
 		return
 	end
 	ya.sleep(math.max(0, 0.1 + start - os.clock()))
 	ya.image_show(cache, job.area)
-	ya.preview_widgets(job, {})
+	ya.preview_widget(job, {})
 end
 
 function M:seek(job, units)
 	local h = cx.active.current.hovered
 	if h and h.url == job.file.url then
 		local step = ya.clamp(-1, units, 1)
-		ya.manager_emit("peek", { math.max(0, cx.active.preview.skip + step), only_if = job.file.url })
+		ya.emit("peek", { math.max(0, cx.active.preview.skip + step), only_if = job.file.url })
 	end
 end
 
@@ -26,7 +26,7 @@ function M:preload(job)
 
 	local percentage = 5 + job.skip
 	if percentage > 95 then
-		ya.manager_emit("peek", { 90, only_if = job.file.url, upper_bound = true })
+		ya.emit("peek", { 90, only_if = job.file.url, upper_bound = true })
 		return 2
 	end
 	local cache = ya.file_cache(job)


### PR DESCRIPTION
## Problem

Two deprecated Yazi API calls cause a runtime crash on Yazi 26.x:

```
Lua error during peek: runtime error: attempt to call a nil value (field 'preview_widgets')
```

Additionally, previews are blank on first visit (issue #1) due to a logic error in `peek`.

## Changes

- `ya.preview_widgets` → `ya.preview_widget` — `preview_widgets` was removed in Yazi 26.x
- `ya.manager_emit` → `ya.emit` — deprecated since Yazi 25.2.26
- Pass `job` to `self:preload(job)` from `peek` — previously called without args, always returning 1 immediately without checking whether f3d had actually rendered the cache file yet. This fixes the blank preview on first visit.

Closes #1

## Tested on

- Yazi 26.5.6
- f3d 3.5.0