### PR TITLE
The code now works in Yazi 26.5.6 and adds the function to open the 3mf image file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Yazi previewer which uses f3d to render 3d object files like: step, stl, obj, 3m
 ## Installation
 
 ```
-ya pkg add "ruudjhuu/f3d-preview"
+ya pkg add "joao41-second/f3d-preview"
 ```
 
 ## Configuration

--- a/main.lua
+++ b/main.lua
@@ -2,12 +2,11 @@ local M = {}
 
 function M:peek(job)
 	local start, cache = os.clock(), ya.file_cache(job)
-	if not cache or self:preload() ~= 1 then
+	if not cache or self:preload(job) ~= 1 then
 		return
 	end
 	ya.sleep(math.max(0, 0.1 + start - os.clock()))
 	ya.image_show(cache, job.area)
-	ya.preview_widgets(job, {})
 end
 
 function M:seek(job, units)
@@ -18,12 +17,36 @@ function M:seek(job, units)
 	end
 end
 
+local function ext_of(url)
+	return tostring(url):match("^.+%.([^.]+)$")
+end
+
+-- Tenta extrair a thumbnail embutida no 3mf. Devolve true se conseguiu.
+local function try_extract_3mf_thumbnail(input, cache)
+	-- 1. descobre o caminho real da thumbnail via _rels/.rels
+	local rels = Command("unzip"):arg({ "-p", input, "_rels/.rels" }):output()
+	local target
+	if rels and rels.status.success then
+		target = rels.stdout:match('Target="([^"]+)"[^>]*[Tt]humbnail')
+			or rels.stdout:match('[Tt]humbnail[^>]*Target="([^"]+)"')
+	end
+	-- 2. fallback para o caminho mais comum, caso o .rels não tenha sido encontrado/lido
+	target = (target or "Metadata/thumbnail.png"):gsub("^/", "")
+
+	-- 3. extrai a imagem
+	local out = Command("unzip"):arg({ "-p", input, target }):output()
+	if not out or not out.status.success or #out.stdout == 0 then
+		return false
+	end
+
+	return fs.write(cache, out.stdout) and true or false
+end
+
 function M:preload(job)
 	ya.dbg("Preloading f3d-preview ***")
 	if not job then
 		return 1
 	end
-
 	local percentage = 5 + job.skip
 	if percentage > 95 then
 		ya.manager_emit("peek", { 90, only_if = job.file.url, upper_bound = true })
@@ -33,27 +56,32 @@ function M:preload(job)
 	if not cache then
 		return 1
 	end
-
 	local cha = fs.cha(cache)
 	if cha and cha.len > 0 then
 		return 1
 	end
 
-	-- generate image
-	ya.err("Calling f3d for: " .. tostring(job.file.url) .. ", cache: " .. tostring(cache))
+	local input = tostring(job.file.url)
+
+	-- usa a thumbnail embutida no 3mf, se existir
+	if ext_of(job.file.url) == "3mf" and try_extract_3mf_thumbnail(input, cache) then
+		ya.err("Used embedded thumbnail for: " .. input)
+		return 1
+	end
+
+	-- caso contrário, renderiza com f3d como antes
+	ya.err("Calling f3d for: " .. input .. ", cache: " .. tostring(cache))
 	local child, code = Command("f3d"):arg({
-		tostring(job.file.url),
+		input,
 		"--no-background",
 		"-tas",
 		"--output",
 		tostring(cache),
 	}):spawn()
-
 	if not child then
 		ya.err("spawn `f3d` command returns " .. tostring(code))
 		return 0
 	end
-
 	local status = child:wait()
 	return status and status.success and 1 or 2
 end


### PR DESCRIPTION

Hello, I came across your plugin today and it wasn't running well on my version of Yazi. So I fixed that and added a function where, when the 3mf file has an image inside, it displays the image instead of generating one.


Yazi
    Version: 26.5.6 (07a5deb 2026-06-10)
    Debug  : false
    Triple : x86_64-unknown-linux-gnu (linux-x86_64)
    Rustc  : 1.96.0 (ac68faa2 2026-05-25)
